### PR TITLE
feat: Enhance rent vs. buy calculator with UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,66 +11,83 @@
     <form id="calculatorForm">
         <div>
             <label for="netMonthlyPay">Net Monthly Pay:</label>
-            <input type="number" id="netMonthlyPay" placeholder="e.g., 15000">
+            <input type="number" id="netMonthlyPay" value="15000" step="100"> <span class="unit-display">$</span>
         </div>
         <div>
             <label for="monthlyExpenses">Monthly Expenses:</label>
-            <input type="number" id="monthlyExpenses" placeholder="e.g., 6000">
+            <input type="number" id="monthlyExpenses" value="4000" step="100"> <span class="unit-display">$</span>
         </div>
         <div>
             <label for="additionalBonus">Additional stock/bonus per year:</label>
-            <input type="number" id="additionalBonus" placeholder="e.g., 0">
+            <input type="number" id="additionalBonus" value="5000" step="1000"> <span class="unit-display">$/year</span>
         </div>
         <div>
             <label for="homePrice">Home Price:</label>
-            <input type="number" id="homePrice" placeholder="e.g., 1850000">
+            <input type="number" id="homePrice" value="500000" step="10000"> <span class="unit-display">$</span>
         </div>
         <div>
             <label for="monthlyRent">Monthly Rent:</label>
-            <input type="number" id="monthlyRent" placeholder="e.g., 6000">
+            <input type="number" id="monthlyRent" value="2500" step="100"> <span class="unit-display">$</span>
         </div>
         <div>
             <label for="annualRentIncrease">Annual Rent Increase %:</label>
-            <input type="number" id="annualRentIncrease" placeholder="e.g., 5">
+            <input type="number" id="annualRentIncrease" value="3" step="0.1"> <span class="unit-display">%</span>
+            <input type="range" id="annualRentIncreaseSlider" min="0" max="15" step="0.5" value="3">
+            <span id="annualRentIncreaseSliderValueOutput">3%</span>
         </div>
         <div>
             <label for="interestRate">Interest Rate %:</label>
-            <input type="number" id="interestRate" placeholder="e.g., 5.75">
+            <input type="number" id="interestRate" value="6.0" step="0.01"> <span class="unit-display">%</span>
+            <input type="range" id="interestRateSlider" min="1" max="15" step="0.125" value="6.0">
+            <span id="interestRateSliderValueOutput">6.0%</span>
         </div>
         <div>
             <label for="propertyTaxRate">Property Tax % (Annual):</label>
-            <input type="number" id="propertyTaxRate" placeholder="e.g., 1.11">
+            <input type="number" id="propertyTaxRate" value="1.1" step="0.01"> <span class="unit-display">%</span>
+            <input type="range" id="propertyTaxRateSlider" min="0" max="5" step="0.1" value="1.1">
+            <span id="propertyTaxRateSliderValueOutput">1.1%</span>
         </div>
         <div>
             <label for="homeInsuranceRate">Home Insurance % of home value (Annual):</label>
-            <input type="number" id="homeInsuranceRate" placeholder="e.g., 0.20">
+            <input type="number" id="homeInsuranceRate" value="0.25" step="0.01"> <span class="unit-display">%</span>
+            <input type="range" id="homeInsuranceRateSlider" min="0" max="2" step="0.05" value="0.25">
+            <span id="homeInsuranceRateSliderValueOutput">0.25%</span>
         </div>
         <div>
             <label for="monthlyMaintenance">Maintenance (Monthly):</label>
-            <input type="number" id="monthlyMaintenance" placeholder="e.g., 500">
+            <input type="number" id="monthlyMaintenance" value="300" step="50"> <span class="unit-display">$/month</span>
         </div>
         <div>
             <label for="spyReturn">S&P 500 Annual Return %:</label>
-            <input type="number" id="spyReturn" placeholder="e.g., 8">
+            <input type="number" id="spyReturn" value="8" step="0.1"> <span class="unit-display">%</span>
+            <input type="range" id="spyReturnSlider" min="0" max="20" step="0.5" value="8">
+            <span id="spyReturnSliderValueOutput">8%</span>
         </div>
         <div>
             <label for="homeAppreciation">Annual Home Appreciation %:</label>
-            <input type="number" id="homeAppreciation" placeholder="e.g., 3">
+            <input type="number" id="homeAppreciation" value="4" step="0.1"> <span class="unit-display">%</span>
+            <input type="range" id="homeAppreciationSlider" min="-5" max="15" step="0.5" value="4">
+            <span id="homeAppreciationSliderValueOutput">4%</span>
         </div>
         <div>
             <label for="downPaymentPercent">Down Payment %:</label>
-            <input type="number" id="downPaymentPercent" placeholder="e.g., 30">
+            <input type="number" id="downPaymentPercent" value="20" step="0.1"> <span class="unit-display">%</span>
+            <input type="range" id="downPaymentPercentSlider" min="0" max="100" step="1" value="20">
+            <span id="downPaymentPercentSliderValueOutput">20%</span>
         </div>
         <div>
             <label for="buyingClosingCostsPercent">Buying Closing Costs %:</label>
-            <input type="number" id="buyingClosingCostsPercent" placeholder="e.g., 2">
+            <input type="number" id="buyingClosingCostsPercent" value="2" step="0.1"> <span class="unit-display">%</span>
+            <input type="range" id="buyingClosingCostsPercentSlider" min="0" max="10" step="0.5" value="2">
+            <span id="buyingClosingCostsPercentSliderValueOutput">2%</span>
         </div>
         <div>
             <label for="currentSavings">Current Savings:</label>
-            <input type="number" id="currentSavings" placeholder="e.g., 800000">
+            <input type="number" id="currentSavings" value="150000" step="1000"> <span class="unit-display">$</span>
         </div>
         <button type="button" id="calculateButton">Calculate</button>
     </form>
+    <div id="input-summary-container"></div>
     <div id="results-container">
         <!-- Results will be displayed here -->
     </div>

--- a/script.js
+++ b/script.js
@@ -245,6 +245,133 @@ function formatCurrency(amount) {
     return amount.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0, maximumFractionDigits: 0 });
 }
 
+
+/**
+ * Displays a summary of the user's inputs and key derived values.
+ * @param {object} inputs - The processed input values from getInputs().
+ */
+function displayInputSummary(inputs) {
+    const summaryContainer = document.getElementById('input-summary-container');
+    summaryContainer.innerHTML = ''; // Clear previous summary
+
+    // --- 1. Calculate Derived Values ---
+    const {
+        homePrice,
+        downPaymentPercentDecimal,
+        interestRateDecimal, // This is already a decimal from getInputs
+        buyingClosingCostsPercentDecimal,
+        currentSavings,
+        propertyTaxRateDecimal,
+        homeInsuranceRateDecimal,
+        monthlyMaintenance,
+        monthlyRent,
+        netMonthlyPay,
+        additionalBonus,
+        monthlyExpenses
+    } = inputs;
+
+    const downPaymentAmount = homePrice * downPaymentPercentDecimal;
+    const closingCostsAmount = homePrice * buyingClosingCostsPercentDecimal;
+    const totalUpfrontCosts = downPaymentAmount + closingCostsAmount;
+    const loanAmount = homePrice - downPaymentAmount;
+    const savingsAfterUpfrontCosts = currentSavings - totalUpfrontCosts;
+
+    const monthlyInterestRate = interestRateDecimal / 12;
+    const numberOfPayments = 30 * 12; // Assuming 30 years
+    let monthlyMortgagePayment = 0;
+    if (loanAmount <= 0) {
+        monthlyMortgagePayment = 0;
+    } else if (monthlyInterestRate > 0) {
+        monthlyMortgagePayment = loanAmount * (monthlyInterestRate * Math.pow(1 + monthlyInterestRate, numberOfPayments)) / (Math.pow(1 + monthlyInterestRate, numberOfPayments) - 1);
+    } else { // No interest, loanAmount > 0
+        monthlyMortgagePayment = loanAmount / numberOfPayments;
+    }
+
+    const monthlyPropertyTax = (homePrice * propertyTaxRateDecimal) / 12;
+    const monthlyHomeInsurance = (homePrice * homeInsuranceRateDecimal) / 12;
+    const totalMonthlyHousingCostsBuy = monthlyMortgagePayment + monthlyPropertyTax + monthlyHomeInsurance + monthlyMaintenance;
+
+    const netMonthlyIncome = netMonthlyPay + (additionalBonus / 12);
+    const savingsSurplusRenting = netMonthlyIncome - monthlyExpenses - monthlyRent;
+    const savingsSurplusBuying = netMonthlyIncome - monthlyExpenses - totalMonthlyHousingCostsBuy;
+
+    // --- 2. Create Table Structure ---
+    const table = document.createElement('table');
+    const tbody = table.createTBody();
+
+    // Helper function to add section headers
+    function addSectionHeader(tbody, title) {
+        const row = tbody.insertRow();
+        const cell = row.insertCell();
+        cell.colSpan = 2;
+        cell.textContent = title;
+        // Styling will be handled by CSS for #input-summary-container th, but we can add a class or specific style if needed
+        // For now, using existing CSS which has a th style. If we want to make it look like a th:
+        cell.style.fontWeight = 'bold';
+        cell.style.backgroundColor = '#f0f0f0'; // Match CSS for th in input summary
+        cell.style.padding = '8px 10px'; // Match CSS
+        cell.style.textAlign = 'left'; // Match CSS
+    }
+
+    // Helper function to add rows
+    function addSummaryRow(tbody, label, value, formatType = 'currency') {
+        const row = tbody.insertRow();
+        const cellLabel = row.insertCell();
+        cellLabel.textContent = label;
+        const cellValue = row.insertCell();
+
+        if (value === undefined || value === null || (typeof value === 'number' && isNaN(value))) {
+            cellValue.textContent = 'N/A';
+        } else if (formatType === 'currency') {
+            cellValue.textContent = formatCurrency(value);
+        } else if (formatType === 'percent') {
+            // value is expected to be already scaled (e.g., 20 for 20%)
+            let digits = 0;
+            if (value < 0.001 && value !== 0) digits = 4; // For very small rates if needed
+            else if (value < 10 && value !== Math.floor(value)) digits = 2;
+            else if (value < 1 && value !== 0) digits = 2;
+            cellValue.textContent = value.toFixed(digits) + '%';
+        } else { // 'number'
+            cellValue.textContent = typeof value === 'number' ? value.toLocaleString() : value;
+        }
+    }
+
+    // --- 3. Populate Table ---
+    addSectionHeader(tbody, 'Key Inputs');
+    addSummaryRow(tbody, 'Home Price:', homePrice, 'currency');
+    addSummaryRow(tbody, 'Down Payment Percent:', downPaymentPercentDecimal * 100, 'percent');
+    addSummaryRow(tbody, 'Interest Rate (Annual):', interestRateDecimal * 100, 'percent');
+    addSummaryRow(tbody, 'Current Savings:', currentSavings, 'currency');
+
+
+    addSectionHeader(tbody, 'Upfront Costs (Buying)');
+    addSummaryRow(tbody, 'Down Payment Amount:', downPaymentAmount, 'currency');
+    addSummaryRow(tbody, 'Closing Costs:', closingCostsAmount, 'currency');
+    addSummaryRow(tbody, 'Total Upfront Costs:', totalUpfrontCosts, 'currency');
+    addSummaryRow(tbody, 'Loan Amount:', loanAmount, 'currency');
+    addSummaryRow(tbody, 'Savings After Upfront Costs:', savingsAfterUpfrontCosts, 'currency');
+
+    addSectionHeader(tbody, 'Estimated Monthly Costs (Buy - Initial)');
+    addSummaryRow(tbody, 'Mortgage Principal & Interest:', monthlyMortgagePayment, 'currency');
+    addSummaryRow(tbody, 'Property Tax:', monthlyPropertyTax, 'currency');
+    addSummaryRow(tbody, 'Home Insurance:', monthlyHomeInsurance, 'currency');
+    addSummaryRow(tbody, 'Maintenance:', monthlyMaintenance, 'currency');
+    addSummaryRow(tbody, 'Total Monthly Housing Costs (Buy):', totalMonthlyHousingCostsBuy, 'currency');
+
+    addSectionHeader(tbody, 'Estimated Monthly Costs (Rent - Initial)');
+    addSummaryRow(tbody, 'Monthly Rent:', monthlyRent, 'currency');
+
+    addSectionHeader(tbody, 'Estimated Monthly Cash Flow (Initial)');
+    addSummaryRow(tbody, 'Net Monthly Income:', netMonthlyIncome, 'currency');
+    addSummaryRow(tbody, 'Monthly Non-Housing Expenses:', monthlyExpenses, 'currency');
+    addSummaryRow(tbody, 'Savings Surplus (Renting):', savingsSurplusRenting, 'currency');
+    addSummaryRow(tbody, 'Savings Surplus (Buying):', savingsSurplusBuying, 'currency');
+
+    // --- 4. Append Table to Container ---
+    summaryContainer.appendChild(table);
+}
+
+
 /**
  * Displays the calculation results in a table and a summary.
  * @param {Array<object>} rentData - Array of yearly data from calculateRentingScenario.
@@ -346,12 +473,61 @@ function displayResults(rentData, buyData) {
 document.addEventListener('DOMContentLoaded', () => {
     const calculateButton = document.getElementById('calculateButton');
 
+    // Helper function to synchronize number input, range slider, and output span
+    function setupInputSync(numberInputId, sliderId, outputId, unit = '%') {
+        const numberInput = document.getElementById(numberInputId);
+        const slider = document.getElementById(sliderId);
+        const output = document.getElementById(outputId);
+
+        if (!numberInput || !slider || !output) {
+            console.warn(`Skipping sync setup for: ${numberInputId}, ${sliderId}, ${outputId}. One or more elements not found.`);
+            return;
+        }
+
+        // Initial display update from number input's default value
+        output.textContent = numberInput.value + unit;
+        // Ensure slider also matches the number input's default value initially
+        slider.value = numberInput.value;
+
+
+        numberInput.addEventListener('input', () => {
+            // Check to prevent potential feedback loops or unnecessary updates
+            if (slider.value !== numberInput.value) {
+                slider.value = numberInput.value;
+            }
+            // Ensure output reflects the potentially constrained value of the number input
+            // (e.g., if user types something out of slider's range, slider will clip it)
+            // For a robust solution, one might re-set numberInput.value = slider.value here if clipping is desired.
+            // For now, assume direct update is fine.
+            output.textContent = numberInput.value + unit;
+        });
+
+        slider.addEventListener('input', () => {
+            if (numberInput.value !== slider.value) {
+                numberInput.value = slider.value;
+            }
+            output.textContent = slider.value + unit;
+        });
+    }
+
+    // Setup synchronization for all relevant inputs
+    setupInputSync('annualRentIncrease', 'annualRentIncreaseSlider', 'annualRentIncreaseSliderValueOutput');
+    setupInputSync('interestRate', 'interestRateSlider', 'interestRateSliderValueOutput');
+    setupInputSync('propertyTaxRate', 'propertyTaxRateSlider', 'propertyTaxRateSliderValueOutput');
+    setupInputSync('homeInsuranceRate', 'homeInsuranceRateSlider', 'homeInsuranceRateSliderValueOutput');
+    setupInputSync('spyReturn', 'spyReturnSlider', 'spyReturnSliderValueOutput');
+    setupInputSync('homeAppreciation', 'homeAppreciationSlider', 'homeAppreciationSliderValueOutput');
+    setupInputSync('downPaymentPercent', 'downPaymentPercentSlider', 'downPaymentPercentSliderValueOutput');
+    setupInputSync('buyingClosingCostsPercent', 'buyingClosingCostsPercentSlider', 'buyingClosingCostsPercentSliderValueOutput');
+
+
     if (calculateButton) {
         calculateButton.addEventListener('click', () => {
             console.log("Calculate button clicked.");
             const userInputs = getInputs();
-            const rentData = calculateRentingScenario(userInputs); // Updated variable name
-            const buyData = calculateBuyingScenario(userInputs); // Still using stub
+            displayInputSummary(userInputs); // Call the new summary function
+            const rentData = calculateRentingScenario(userInputs);
+            const buyData = calculateBuyingScenario(userInputs);
             displayResults(rentData, buyData);
         });
     } else {

--- a/style.css
+++ b/style.css
@@ -23,25 +23,56 @@ h1 {
 }
 
 /* Form Input and Label Styling */
-#calculatorForm div { /* Targeting the divs wrapping label and input for spacing */
-    margin-bottom: 15px;
+#calculatorForm > div { /* Direct children divs of the form */
+    display: flex;
+    flex-wrap: wrap; /* Allow wrapping if screen is too narrow */
+    align-items: center; /* Vertically align items */
+    margin-bottom: 15px; /* Existing margin */
 }
 
 label {
-    display: block;
-    margin-bottom: 5px; /* Space between label and input */
+    flex-basis: 100%; /* Label takes full width, effectively on its own line */
+    margin-bottom: 5px; /* Space between label and input group */
     font-weight: bold;
     color: #555;
 }
 
 input[type="number"] {
-    width: 100%;
+    /* width: 100%; */ /* Overridden by flex properties */
+    flex-grow: 1;
+    max-width: 180px; /* Fixed width for number input part */
     padding: 10px;
-    margin-top: 4px; /* Small space if label is block and input is next line conceptually */
+    /* margin-top: 4px; */ /* No longer needed due to flex alignment */
     border: 1px solid #ccc;
     border-radius: 4px;
-    box-sizing: border-box; /* Important for 100% width to include padding and border */
+    box-sizing: border-box;
 }
+
+.unit-display {
+    margin-left: 5px;
+    margin-right: 10px; /* Space before slider if present */
+    color: #555;
+    font-size: 0.9em;
+}
+
+input[type="range"] {
+    flex-grow: 2; /* Slider takes more space */
+    min-width: 100px; /* Prevent slider from becoming too small */
+    height: 10px; /* Visual adjustment for slider height */
+    margin-left: 10px;
+    margin-right: 10px;
+    accent-color: #007bff; /* Match button color */
+}
+
+/* Span for slider value output */
+#calculatorForm > div > span[id$="SliderValueOutput"] { /* Selects spans whose id ends with SliderValueOutput */
+    min-width: 45px; /* Give it some space */
+    text-align: right;
+    font-size: 0.9em;
+    color: #333;
+    font-weight: bold;
+}
+
 
 /* Button Styling */
 #calculateButton {
@@ -103,4 +134,46 @@ input[type="number"] {
     font-size: 1.1em;
     font-weight: bold;
     text-align: center;
+}
+
+/* Input Summary Table Styling */
+#input-summary-container {
+    margin-bottom: 30px; /* Space before main results table */
+}
+
+#input-summary-container table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+    background-color: #fff; /* Similar to other containers */
+    padding: 15px; /* Padding inside the container if table is not full width of it */
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+}
+
+#input-summary-container th, 
+#input-summary-container td {
+    border: 1px solid #e0e0e0; /* Slightly lighter border */
+    padding: 8px 10px;
+    text-align: left;
+}
+
+#input-summary-container th {
+    background-color: #f0f0f0; /* Lighter header than results table */
+    font-weight: bold;
+    color: #444;
+}
+
+/* For two-column layout in summary table where first td is like a header */
+#input-summary-container td:first-child {
+    font-weight: normal; 
+    background-color: #fdfdfd;
+    width: 40%; /* Give more space to description */
+    color: #333;
+}
+
+#input-summary-container td:last-child {
+    text-align: right; /* Numerical values right-aligned */
+    font-weight: bold;
+    color: #0056b3; /* Match button hover color for emphasis */
 }


### PR DESCRIPTION
I've implemented several UI and UX enhancements to the rent vs. buy calculator:
- Added unit displays (e.g., "$", "%") next to input fields.
- Set common default values for all inputs.
- Introduced synchronized range sliders for percentage-based inputs, alongside number inputs.
- Implemented an input summary table that displays key derived values and monthly cash flow estimates before the main 30-year comparison.
- All underlying calculations and the main results table remain functional.

Note: I was unable to update the README.md file with documentation for these new features due to persistent errors. The full content for the updated README was drafted and is available in the development history.