### PR TITLE
feat: Add ADU income, selling costs, unrecoverable costs, and graphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Rent vs. Buy Calculator</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <h1>Rent vs. Buy Calculator</h1>
@@ -20,6 +21,12 @@
         <div>
             <label for="additionalBonus">Additional stock/bonus per year:</label>
             <input type="number" id="additionalBonus" value="5000" step="1000"> <span class="unit-display">$/year</span>
+        </div>
+        <div>
+            <label for="aduMonthlyIncome">Monthly ADU Rent Income:</label>
+            <input type="number" id="aduMonthlyIncome" value="0" step="50"> <span class="unit-display">$</span>
+            <input type="range" id="aduMonthlyIncomeSlider" min="0" max="5000" step="50" value="0">
+            <span id="aduMonthlyIncomeSliderValueOutput">0$</span>
         </div>
         <div>
             <label for="homePrice">Home Price:</label>
@@ -90,6 +97,12 @@
     <div id="input-summary-container"></div>
     <div id="results-container">
         <!-- Results will be displayed here -->
+        <div class="chart-container" style="margin-bottom: 30px;"><canvas id="netWorthChart"></canvas></div>
+    </div>
+    <div id="unrecoverable-costs-container">
+        <h2>Unrecoverable Costs Over Time</h2>
+        <!-- Table will be inserted here by JS -->
+        <div class="chart-container"><canvas id="unrecoverableCostsChart"></canvas></div>
     </div>
     <script src="script.js" defer></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,8 @@
 // script.js
 
+let netWorthChartInstance = null;
+let unrecoverableCostsChartInstance = null;
+
 /**
  * Retrieves and processes input values from the form.
  * Converts percentage inputs to decimal format.
@@ -17,6 +20,7 @@ function getInputs() {
     inputs.netMonthlyPay = getFloatValue('netMonthlyPay');
     inputs.monthlyExpenses = getFloatValue('monthlyExpenses');
     inputs.additionalBonus = getFloatValue('additionalBonus'); // This is an annual amount
+    inputs.aduMonthlyIncome = getFloatValue('aduMonthlyIncome'); // ADU Income
 
     // Home Purchase Inputs
     inputs.homePrice = getFloatValue('homePrice');
@@ -54,6 +58,7 @@ function calculateRentingScenario(inputs) {
 
     let currentAnnualRent = inputs.monthlyRent * 12;
     let investedAssets = inputs.currentSavings;
+    let totalRentPaid = 0; // Initialize totalRentPaid
 
     // Extracting necessary inputs for clarity within the loop
     const {
@@ -80,12 +85,14 @@ function calculateRentingScenario(inputs) {
         investedAssets += savingsThisYear;
         // Then apply S&P return to the new total
         investedAssets *= (1 + spyReturnDecimal);
+        totalRentPaid += currentAnnualRent; // Accumulate rent paid
 
         rentResults.push({
             year: year,
             rentPaidThisYear: currentAnnualRent,
             netWorth: investedAssets,
-            savingsForYear: savingsThisYear // For detailed analysis
+            savingsForYear: savingsThisYear, // For detailed analysis
+            totalUnrecoverableCost: totalRentPaid // Add total unrecoverable cost
         });
     }
 
@@ -102,6 +109,7 @@ function calculateBuyingScenario(inputs) {
     console.log("calculateBuyingScenario received inputs:", inputs);
     const yearsToSimulate = 30;
     const buyResults = [];
+    let totalUnrecoverableBuyCosts = 0; // Initialize totalUnrecoverableBuyCosts
 
     const {
         homePrice,
@@ -116,7 +124,8 @@ function calculateBuyingScenario(inputs) {
         spyReturnDecimal,
         buyingClosingCostsPercentDecimal,
         currentSavings,
-        additionalBonus
+        additionalBonus,
+        aduMonthlyIncome // Destructure new input
     } = inputs;
 
     // Initial Purchase Calculations
@@ -200,7 +209,8 @@ function calculateBuyingScenario(inputs) {
         // totalHousingCostsThisYear based on actual mortgage payments made + other costs
         const totalHousingCostsThisYear = actualAnnualMortgagePaid + propertyTaxPaidThisYear + homeInsurancePaidThisYear + maintenancePaidThisYear;
 
-        const annualNetIncome = (netMonthlyPay * 12) + additionalBonus;
+        // Include ADU income in annual net income for buying scenario
+        const annualNetIncome = (netMonthlyPay * 12) + additionalBonus + (aduMonthlyIncome * 12);
         const annualLivingExpenses = monthlyExpenses * 12; // General living expenses
         const savingsThisYear = annualNetIncome - totalHousingCostsThisYear - annualLivingExpenses;
 
@@ -212,8 +222,12 @@ function calculateBuyingScenario(inputs) {
         }
 
 
-        const homeEquity = currentHomeValue - (remainingLoanBalance > 0 ? remainingLoanBalance : 0);
+        // Factor in 6% selling cost for home equity calculation
+        const homeEquity = (currentHomeValue * 0.94) - (remainingLoanBalance > 0 ? remainingLoanBalance : 0);
         const netWorth = homeEquity + investedAssets;
+
+        const unrecoverableThisYear = interestPaidThisYear + propertyTaxPaidThisYear + homeInsurancePaidThisYear + maintenancePaidThisYear;
+        totalUnrecoverableBuyCosts += unrecoverableThisYear;
 
         buyResults.push({
             year: year,
@@ -225,7 +239,8 @@ function calculateBuyingScenario(inputs) {
             interestPaid: interestPaidThisYear,
             principalPaid: principalPaidThisYear,
             annualHousingCost: totalHousingCostsThisYear, // For more detailed analysis later
-            savingsForYear: savingsThisYear
+            savingsForYear: savingsThisYear,
+            totalUnrecoverableCost: totalUnrecoverableBuyCosts // Add total unrecoverable cost
         });
     }
 
@@ -267,7 +282,8 @@ function displayInputSummary(inputs) {
         monthlyRent,
         netMonthlyPay,
         additionalBonus,
-        monthlyExpenses
+        monthlyExpenses,
+        aduMonthlyIncome // Destructure for summary
     } = inputs;
 
     const downPaymentAmount = homePrice * downPaymentPercentDecimal;
@@ -291,9 +307,11 @@ function displayInputSummary(inputs) {
     const monthlyHomeInsurance = (homePrice * homeInsuranceRateDecimal) / 12;
     const totalMonthlyHousingCostsBuy = monthlyMortgagePayment + monthlyPropertyTax + monthlyHomeInsurance + monthlyMaintenance;
 
-    const netMonthlyIncome = netMonthlyPay + (additionalBonus / 12);
-    const savingsSurplusRenting = netMonthlyIncome - monthlyExpenses - monthlyRent;
+    // Include ADU income in net monthly income for summary calculation
+    const netMonthlyIncome = netMonthlyPay + (additionalBonus / 12) + aduMonthlyIncome;
+    const savingsSurplusRenting = netMonthlyIncome - monthlyExpenses - monthlyRent - aduMonthlyIncome; // ADU income not available when renting
     const savingsSurplusBuying = netMonthlyIncome - monthlyExpenses - totalMonthlyHousingCostsBuy;
+
 
     // --- 2. Create Table Structure ---
     const table = document.createElement('table');
@@ -341,6 +359,7 @@ function displayInputSummary(inputs) {
     addSummaryRow(tbody, 'Home Price:', homePrice, 'currency');
     addSummaryRow(tbody, 'Down Payment Percent:', downPaymentPercentDecimal * 100, 'percent');
     addSummaryRow(tbody, 'Interest Rate (Annual):', interestRateDecimal * 100, 'percent');
+    addSummaryRow(tbody, 'Monthly ADU Rent Income:', aduMonthlyIncome, 'currency'); // Display ADU Income
     addSummaryRow(tbody, 'Current Savings:', currentSavings, 'currency');
 
 
@@ -469,6 +488,156 @@ function displayResults(rentData, buyData) {
     resultsContainer.appendChild(summaryP);
 }
 
+/**
+ * Displays the unrecoverable costs in a table.
+ * @param {Array<object>} rentData - Array of yearly data from calculateRentingScenario.
+ * @param {Array<object>} buyData - Array of yearly data from calculateBuyingScenario.
+ */
+function displayUnrecoverableCosts(rentData, buyData) {
+    const container = document.getElementById('unrecoverable-costs-container');
+    
+    // Clear previous table if any, but keep H2 (or recreate H2 if preferred)
+    const existingTable = container.querySelector('table');
+    if (existingTable) {
+        existingTable.remove();
+    }
+
+    if (!rentData || !buyData || rentData.length === 0 || buyData.length === 0) {
+        // Optionally display a message if data is missing
+        // For now, just don't create the table if data isn't there
+        return; 
+    }
+
+    const table = document.createElement('table');
+    const thead = table.createTHead();
+    const headerRow = thead.insertRow();
+    const headers = ['Year', 'Total Unrecoverable (Rent)', 'Total Unrecoverable (Buy)'];
+    headers.forEach(text => {
+        const th = document.createElement('th');
+        th.textContent = text;
+        headerRow.appendChild(th);
+    });
+
+    const tbody = table.createTBody();
+    for (let i = 0; i < rentData.length; i++) {
+        // Check if corresponding buyData exists for safety, though they should have same length
+        if (i >= buyData.length) continue; 
+
+        const yearRent = rentData[i];
+        const yearBuy = buyData[i];
+        const row = tbody.insertRow();
+
+        row.insertCell().textContent = yearRent.year;
+        // Ensure totalUnrecoverableCost property exists before formatting
+        row.insertCell().textContent = yearRent.totalUnrecoverableCost !== undefined ? formatCurrency(yearRent.totalUnrecoverableCost) : 'N/A';
+        row.insertCell().textContent = yearBuy.totalUnrecoverableCost !== undefined ? formatCurrency(yearBuy.totalUnrecoverableCost) : 'N/A';
+    }
+    container.appendChild(table);
+}
+
+/**
+ * Displays charts for Net Worth and Unrecoverable Costs.
+ * @param {Array<object>} rentData - Array of yearly data from calculateRentingScenario.
+ * @param {Array<object>} buyData - Array of yearly data from calculateBuyingScenario.
+ */
+function displayCharts(rentData, buyData) {
+    if (!rentData || !buyData || rentData.length === 0 || buyData.length === 0) {
+        // Optionally clear charts or display a message if data is missing
+        if (netWorthChartInstance) netWorthChartInstance.destroy();
+        if (unrecoverableCostsChartInstance) unrecoverableCostsChartInstance.destroy();
+        netWorthChartInstance = null;
+        unrecoverableCostsChartInstance = null;
+        return; 
+    }
+
+    const years = rentData.map(d => d.year); // Assuming years are consistent
+
+    // Data for Net Worth Chart
+    const netWorthRentValues = rentData.map(d => d.netWorth);
+    const netWorthBuyValues = buyData.map(d => d.netWorth);
+
+    // Data for Unrecoverable Costs Chart
+    const unrecoverableRentValues = rentData.map(d => d.totalUnrecoverableCost);
+    const unrecoverableBuyValues = buyData.map(d => d.totalUnrecoverableCost);
+
+    // Destroy previous charts if they exist
+    if (netWorthChartInstance) {
+        netWorthChartInstance.destroy();
+    }
+    if (unrecoverableCostsChartInstance) {
+        unrecoverableCostsChartInstance.destroy();
+    }
+
+    // Net Worth Chart
+    const nwCtx = document.getElementById('netWorthChart').getContext('2d');
+    netWorthChartInstance = new Chart(nwCtx, {
+        type: 'line',
+        data: {
+            labels: years,
+            datasets: [
+                {
+                    label: 'Renting Net Worth',
+                    data: netWorthRentValues,
+                    borderColor: 'rgba(255, 99, 132, 1)', // Reddish
+                    backgroundColor: 'rgba(255, 99, 132, 0.2)',
+                    tension: 0.1
+                },
+                {
+                    label: 'Buying Net Worth',
+                    data: netWorthBuyValues,
+                    borderColor: 'rgba(54, 162, 235, 1)', // Bluish
+                    backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                    tension: 0.1
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true, 
+            plugins: {
+                title: { display: true, text: 'Net Worth Over Time' },
+                tooltip: { callbacks: { label: (context) => `${context.dataset.label}: ${formatCurrency(context.raw)}` } }
+            },
+            scales: { y: { ticks: { callback: (value) => formatCurrency(value) } } }
+        }
+    });
+
+    // Unrecoverable Costs Chart
+    const ucCtx = document.getElementById('unrecoverableCostsChart').getContext('2d');
+    unrecoverableCostsChartInstance = new Chart(ucCtx, {
+        type: 'line',
+        data: {
+            labels: years,
+            datasets: [
+                {
+                    label: 'Unrecoverable Costs (Rent)',
+                    data: unrecoverableRentValues,
+                    borderColor: 'rgba(255, 159, 64, 1)', // Orangeish
+                    backgroundColor: 'rgba(255, 159, 64, 0.2)',
+                    tension: 0.1
+                },
+                {
+                    label: 'Unrecoverable Costs (Buy)',
+                    data: unrecoverableBuyValues,
+                    borderColor: 'rgba(75, 192, 192, 1)', // greenish-blue
+                    backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                    tension: 0.1
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+                title: { display: true, text: 'Total Unrecoverable Costs Over Time' },
+                tooltip: { callbacks: { label: (context) => `${context.dataset.label}: ${formatCurrency(context.raw)}` } }
+            },
+            scales: { y: { ticks: { callback: (value) => formatCurrency(value) } } }
+        }
+    });
+}
+
+
 // Event Listener for the Calculate Button
 document.addEventListener('DOMContentLoaded', () => {
     const calculateButton = document.getElementById('calculateButton');
@@ -519,6 +688,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupInputSync('homeAppreciation', 'homeAppreciationSlider', 'homeAppreciationSliderValueOutput');
     setupInputSync('downPaymentPercent', 'downPaymentPercentSlider', 'downPaymentPercentSliderValueOutput');
     setupInputSync('buyingClosingCostsPercent', 'buyingClosingCostsPercentSlider', 'buyingClosingCostsPercentSliderValueOutput');
+    setupInputSync('aduMonthlyIncome', 'aduMonthlyIncomeSlider', 'aduMonthlyIncomeSliderValueOutput', '$'); // Sync for ADU
 
 
     if (calculateButton) {
@@ -529,6 +699,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const rentData = calculateRentingScenario(userInputs);
             const buyData = calculateBuyingScenario(userInputs);
             displayResults(rentData, buyData);
+            displayUnrecoverableCosts(rentData, buyData); 
+            displayCharts(rentData, buyData); // Call the new chart function
         });
     } else {
         console.error("Calculate button not found!");

--- a/style.css
+++ b/style.css
@@ -177,3 +177,52 @@ input[type="range"] {
     font-weight: bold;
     color: #0056b3; /* Match button hover color for emphasis */
 }
+
+/* Unrecoverable Costs Table Styling */
+#unrecoverable-costs-container {
+    margin-top: 30px; /* Space above this section */
+}
+#unrecoverable-costs-container h2 {
+    text-align: center;
+    margin-bottom: 15px;
+    color: #333; /* Match other h1/h2 if any */
+}
+#unrecoverable-costs-container table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px; /* Space between H2 and table */
+    background-color: #fff; /* Match other table containers */
+    border-radius: 8px; /* Match other table containers */
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.05); /* Match other table containers */
+}
+#unrecoverable-costs-container th,
+#unrecoverable-costs-container td {
+    border: 1px solid #ddd;
+    padding: 8px 10px;
+    text-align: left;
+}
+#unrecoverable-costs-container th {
+    background-color: #e9e9e9; /* Match other table headers */
+}
+/* Right-align numerical data */
+#unrecoverable-costs-container td:nth-child(2),
+#unrecoverable-costs-container th:nth-child(2),
+#unrecoverable-costs-container td:nth-child(3),
+#unrecoverable-costs-container th:nth-child(3) {
+    text-align: right;
+}
+
+/* Chart Styling */
+.chart-container {
+    width: 100%;
+    max-width: 700px; /* Or your preferred max width */
+    margin: 30px auto; /* Center the chart and add space */
+    padding: 10px;
+    border: 1px solid #eee;
+    border-radius: 8px;
+    background-color: #fff; /* Optional background for the chart area */
+}
+
+canvas {
+    max-width: 100%; /* Ensure canvas scales down */
+}


### PR DESCRIPTION
I've completed the Rent vs. Buy calculator with several advanced features:
- New input for Monthly ADU Rent Income, factored into the buying scenario.
- Incorporated a 6% selling cost into the yearly home equity calculation for the buying scenario.
- Calculates and displays total unrecoverable costs for both renting and buying scenarios in a new table.
- Visualizes Net Worth Over Time and Total Unrecoverable Costs Over Time using Chart.js line graphs.
- All previous functionalities, including the input summary table and synchronized sliders, are maintained.

The application is feature-complete.

Note: I was unable to update the README.md file with documentation for these latest features due to persistent errors. The full content for the updated README was drafted and is available in the development history.